### PR TITLE
Fix push logic and createdDateTime bug

### DIFF
--- a/app/oadr/convert_event.rb
+++ b/app/oadr/convert_event.rb
@@ -240,7 +240,7 @@ private
     oadr_event.ei_event.event_descriptor.ei_market_context = Oadr2bFactory.create_market_context(event.market_context.name)
 
     # created_date_time is the last time the message was generated, not the first time the event was created
-    oadr_event.ei_event.event_descriptor.created_date_time = ZuluTime.get_gregorian_calendar_ruby_dt(event.updated_at)
+    oadr_event.ei_event.event_descriptor.created_date_time = ZuluTime.get_gregorian_calendar_ruby_dt(event.created_at)
     oadr_event.ei_event.event_descriptor.event_status = ConvertStringToEnum.instance.convert_event_status(event.event_status.nil? ? "" : event.event_status.name)
     oadr_event.ei_event.event_descriptor.test_event = event.test_event
     oadr_event.ei_event.event_descriptor.vtn_comment = event.vtn_comment

--- a/app/oadr/convert_event_a.rb
+++ b/app/oadr/convert_event_a.rb
@@ -222,7 +222,7 @@ class ConvertEventA
     oadr_event.ei_event.event_descriptor.ei_market_context = Oadr2aFactory.create_market_context(event.market_context.name)
 
     # created_date_time is the last time the message was generated, not the first time the event was created
-    oadr_event.ei_event.event_descriptor.created_date_time = ZuluTime.get_gregorian_calendar_ruby_dt(event.updated_at)
+    oadr_event.ei_event.event_descriptor.created_date_time = ZuluTime.get_gregorian_calendar_ruby_dt(event.created_at)
 
     oadr_event.ei_event.event_descriptor.event_status = ConvertStringToEnum.instance.convert_event_status_a(event.event_status.nil? ? "" : event.event_status.name)
 

--- a/app/services/http/http_agent_b.rb
+++ b/app/services/http/http_agent_b.rb
@@ -204,7 +204,7 @@ class HttpAgentB < HttpAgent
 
     OadrLogger.instance.log_info("push message to #{@ven.transport_address}")
 
-    response = @http_client.post(@ven.registration.oadr_transport_address + "/OpenADR2/Simple/2.0b/#{ven_message.service_type.name}", ven_message.oadr_message)
+    response = @http_client.post(@ven.transport_address + "/OpenADR2/Simple/2.0b/#{ven_message.service_type.name}", ven_message.oadr_message)
 
     response
   end

--- a/app/services/push_message_manager.rb
+++ b/app/services/push_message_manager.rb
@@ -220,23 +220,6 @@ class PushMessageManager
       agent = XmppAgent.new(ven.id, @xmpp_service_handler)
     end
 
-    # if ven.http_push?
-    #   OadrLogger.instance.log_info("starting http A agent for ven: #{ven.id}")
-    #
-    #   agant = agent = HttpAgentA.new(ven.id, @options)
-    #
-    # elsif ven.registration.oadr_transport_name == 'simpleHttp'
-    #   OadrLogger.instance.log_info("starting http B agent for ven: #{ven.id}")
-    #
-    #   # is it an HTTP or XMPP agent? profile a or b
-    #   agent = HttpAgentB.new(ven.id, @options)
-    # else
-    #   OadrLogger.instance.log_info("starting xmpp agent for ven: #{ven.id}")
-    #
-    #   agent = XmppAgent.new(ven.id, @xmpp_service_handler)
-    #
-    # end
-
     agent.start
 
     agent

--- a/app/services/push_message_manager.rb
+++ b/app/services/push_message_manager.rb
@@ -207,22 +207,35 @@ class PushMessageManager
 
     OadrLogger.instance.log_info("starting agent for ven: #{ven.id}")
 
-    if ven.http_push?
-      OadrLogger.instance.log_info("starting http A agent for ven: #{ven.id}")
-
-      agant = agent = HttpAgentA.new(ven.id, @options)
-
-    elsif ven.registration.oadr_transport_name == 'simpleHttp'
-      OadrLogger.instance.log_info("starting http B agent for ven: #{ven.id}")
-
-      # is it an HTTP or XMPP agent? profile a or b
-      agent = HttpAgentB.new(ven.id, @options)
+    if ven.registration.oadr_transport_name == 'simpleHttp'
+      if ven.profile.name == "2.0a"
+        OadrLogger.instance.log_info("starting http A agent for ven: #{ven.id}")
+        agent = HttpAgentA.new(ven.id, @options)
+      else
+        OadrLogger.instance.log_info("starting http B agent for ven: #{ven.id}")
+        agent = HttpAgentB.new(ven.id, @options)
+      end
     else
       OadrLogger.instance.log_info("starting xmpp agent for ven: #{ven.id}")
-
       agent = XmppAgent.new(ven.id, @xmpp_service_handler)
-
     end
+
+    # if ven.http_push?
+    #   OadrLogger.instance.log_info("starting http A agent for ven: #{ven.id}")
+    #
+    #   agant = agent = HttpAgentA.new(ven.id, @options)
+    #
+    # elsif ven.registration.oadr_transport_name == 'simpleHttp'
+    #   OadrLogger.instance.log_info("starting http B agent for ven: #{ven.id}")
+    #
+    #   # is it an HTTP or XMPP agent? profile a or b
+    #   agent = HttpAgentB.new(ven.id, @options)
+    # else
+    #   OadrLogger.instance.log_info("starting xmpp agent for ven: #{ven.id}")
+    #
+    #   agent = XmppAgent.new(ven.id, @xmpp_service_handler)
+    #
+    # end
 
     agent.start
 


### PR DESCRIPTION
## [Fix #1] 
- 인증 시험 테스트 시 createdDateTime이 맞지 않는 에러 발생.
- Push url이 잘못됨.

## [Change]
- `updated_at`을 `created_at`으로 변경
- push 로직 수정.
  - 존재하지 않는 table column을 조회하고 있는 부분 수정. (`registration.oadr_transport_address` -> `transport_address`)
  - 2.0a, 2.0b 둘 다 `pull`, `push` 방식 지원 해야하는데 기존 코드는 `push`인 경우 2.0a url을 호출하도록 되어있었음. 

## [How Verified]
- createdDateTime
  - rubymine 사용하여 로컬에서 테스트 (Event: `E1_1040_TH_VEN` pass)
- push
  - docker 띄워서 테스트 (torquebox가 `push_message_manager`를 돌려주기 때문)